### PR TITLE
Firestore kitap ekleme izin hatası

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,18 +1,36 @@
-rules_version='2'
-
+rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
-      allow read, write: if request.time < timestamp.date(2025, 9, 8);
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // Onay kontrolü hem custom claim hem de users/{uid} dokümanından yapılır
+    function isApproved() {
+      return isSignedIn() && (
+        request.auth.token.approved == true ||
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.approved == true
+      );
+    }
+
+    // users koleksiyonu
+    match /users/{userId} {
+      allow create: if isSignedIn()
+                    && request.auth.uid == userId
+                    && request.resource.data.keys().hasAny(['email','approved','createdAt'])
+                    && request.resource.data.approved == false
+                    && request.resource.data.email == request.auth.token.email;
+      allow read: if isSignedIn() && request.auth.uid == userId;
+      // Kullanıcı kendi dokümanını güncelleyemesin (onay admin tarafından verilir)
+      allow update, delete: if false;
+    }
+
+    // books koleksiyonu
+    match /books/{bookId} {
+      allow create: if isApproved()
+                    && request.resource.data.ownerId == request.auth.uid;
+      allow read, update, delete: if isApproved()
+                                  && resource.data.ownerId == request.auth.uid;
     }
   }
 }


### PR DESCRIPTION
Update Firestore rules to allow book creation by checking user approval from either custom claims or the user's document.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f9c8815-6d56-42d4-b0f0-47bf12e53505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f9c8815-6d56-42d4-b0f0-47bf12e53505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

